### PR TITLE
Ability to retrieve data source info

### DIFF
--- a/MDX2JSON/REST.cls.xml
+++ b/MDX2JSON/REST.cls.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Export generator="Cache" version="25">
+<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2014.1.1 (Build 702U)" ts="2014-11-24 20:24:29">
 <Class name="MDX2JSON.REST">
 <Description><![CDATA[
 Class for REST-like web api for MDX2JSON transformation (and XML/A).<br>
 Example: send HTTP POST request to web application with Dispatch class <b>MDX2JSON.REST</b>
 with body: { "MDX":"QUERY" }, where QUERY is a correct MDX statement, ex:  <br> 
 {<br>
-		"MDX": "SELECT NON EMPTY [Product].[P1].[Product Category].Members ON 0,NON EMPTY [Outlet].[H1].[Region].Members ON 1 FROM [HoleFoods]"<br>
+        "MDX": "SELECT NON EMPTY [Product].[P1].[Product Category].Members ON 0,NON EMPTY [Outlet].[H1].[Region].Members ON 1 FROM [HoleFoods]"<br>
 } <br>
 You can send requests to:<br> <ul>
-	<li>webapplication/Test - to get test info, %request, %response and %session</li> 
-	<li>webapplication/MDX - to get result in JSON format for MDX query</li>
-	<li>webapplication/MDXDrillthrough - to get resulting listing in JSON format for MDX Drillthrough query</li>
-	<li>webapplication/MDX2XMLA - to get result in XML/A format for MDX query</li>
+    <li>webapplication/Test - to get test info, %request, %response and %session</li> 
+    <li>webapplication/MDX - to get result in JSON format for MDX query</li>
+    <li>webapplication/MDXDrillthrough - to get resulting listing in JSON format for MDX Drillthrough query</li>
+    <li>webapplication/MDX2XMLA - to get result in XML/A format for MDX query</li>
 </ul>
 
 Dashboard related requests are:
  <ul>
- 	<li>webapplication/Dashboards - get all dashboards in a namespace (GET request).</li>
-	<li>webapplication/Widgets - get all dashboard widgets (POST request with {Dashboard:"DashboardName"} body).</li>
+    <li>webapplication/Dashboards - get all dashboards in a namespace (GET request).</li>
+    <li>webapplication/Widgets - get all dashboard widgets (POST request with {Dashboard:"DashboardName"} body).</li>
 </ul>
 To get information about possible Cube's filters and filters' values:<br><ul>
-		<li>webapplication/FilterValues/:cube - to get all filters for DeepSee Cube in JSON format.</li> 
-		<li>webapplication/FilterValues/:cube/:filter - to get all values for Filter for DeepSee Cube in JSON format.</li></ul> 
+        <li>webapplication/FilterValues/:cube - to get all filters for DeepSee Cube in JSON format.</li> 
+        <li>webapplication/FilterValues/:cube/:filter - to get all values for Filter for DeepSee Cube in JSON format.</li></ul> 
 Example: send HTTP GET request to web application with Dispatch class <b>MDX2JSON.REST</b> and URL:<br>
 /FilterValues/HoleFoods/[DateOfSale].[Actual].[MonthSold] -  to get information about possible values of [DateOfSale].[Actual].[MonthSold] in HoleFoods Cube.<br>
 You can add a param Namespace to request to execute MDX in desired namespace (MDX2JSON package must be mapped to that namespace):<br>
@@ -30,12 +30,13 @@ webapplication/MDX?Namespace=Samples
 ]]></Description>
 <IncludeCode>MDX2JSON.MDX2JSON</IncludeCode>
 <Super>%CSP.REST</Super>
+<TimeChanged>63515,67956.917968</TimeChanged>
 <TimeCreated>63165,65257.8179</TimeCreated>
 
 <XData name="UrlMap">
 <Data><![CDATA[
 <Routes>
-	<!-- Send objects in this format: {"MDX":"QUERY"} HTTP method: POST	-->
+    <!-- Send objects in this format: {"MDX":"QUERY"} HTTP method: POST -->
    <Route Url="/MDX" Method="POST" Call="WriteJSONfromMDX"/>
    <Route Url="/MDX2JSONP" Method="POST" Call="WriteJSONPfromMDX"/>  
    <Route Url="/MDXDrillthrough" Method="POST" Call="WriteDrillthroughJSON"/>
@@ -49,6 +50,8 @@ webapplication/MDX?Namespace=Samples
       
     <Route Url="/Dashboards" Method="GET" Call="GetDashboardsList"/> 
     <Route Url="/Widgets" Method="POST" Call="GetWidgetsList"/>   
+     
+   <Route Url="/DataSource" Method="POST" Call="GetDataSource"/>   
      
    <!-- Valid but illicit, do not use-->
    <Route Url="/MDX/:query" Method="GET" Call="WriteJSONfromMDXURL"/>  
@@ -66,13 +69,23 @@ Test method, outputs <b>%request</b>, <b>%response</b> and <b>%session</b> objec
 <ClassMethod>1</ClassMethod>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	&html<<h1>Status: OK!</h1><br>>
-	zw %request
-	&html<<br><br>>
-	zw %response
-	&html<<br><br>>
-	zw %session
-	return $$$OK
+    &html<<h1>Status: OK!</h1><br>>
+    zw %request
+    &html<<br><br>>
+    zw %response
+    &html<<br><br>>
+    zw %session
+    return $$$OK
+]]></Implementation>
+</Method>
+
+<Method name="GetDataSource">
+<ClassMethod>1</ClassMethod>
+<Implementation><![CDATA[
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
+    return:$$$ISERR(st) st
+    set dataSource = $ZCVT(obj.DataSource,"I","UTF8")
+    return ##class(MDX2JSON.Utils).GetDataSource(dataSource)
 ]]></Implementation>
 </Method>
 
@@ -82,14 +95,14 @@ Wrapper for ##class(MDX2JSON.Utils).GetWidgetsList()<br>
 Converts incoming request object (JSON: {Dashboard:"Dashboard Full Name"} and calls abovementioned method.]]></Description>
 <ClassMethod>1</ClassMethod>
 <Implementation><![CDATA[
-	set dashboard = $$$get("w")
-	if (dashboard = "") {
-		set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
-		return:$$$ISERR(st) st
-		set dashboard = obj.Dashboard
-		set dashboard = $ZCVT(dashboard,"I","UTF8")
-	}
-	return ##class(MDX2JSON.Utils).GetWidgetsList(dashboard)
+    set dashboard = $$$get("w")
+    if (dashboard = "") {
+        set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
+        return:$$$ISERR(st) st
+        set dashboard = obj.Dashboard
+        set dashboard = $ZCVT(dashboard,"I","UTF8")
+    }
+    return ##class(MDX2JSON.Utils).GetWidgetsList(dashboard)
 ]]></Implementation>
 </Method>
 
@@ -99,14 +112,14 @@ Returns JSON array of (title, path) for all dashboards in namespace (accessible 
 <ClassMethod>1</ClassMethod>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set sql = "SELECT title, fullName As path FROM %DeepSee_Dashboard.Definition WHERE folderName = 'Mobile'"
-	try {
-		
-		do ##class(%ZEN.Auxiliary.jsonSQLProvider).%WriteJSONFromSQL(,sql)
-	} catch ex {
-		write $$$ZENJSSTR($System.Status.GetErrorText(ex.AsStatus()))
-	}
-	return $$$OK
+    set sql = "SELECT title, fullName As path FROM %DeepSee_Dashboard.Definition WHERE folderName = 'Mobile'"
+    try {
+        
+        do ##class(%ZEN.Auxiliary.jsonSQLProvider).%WriteJSONFromSQL(,sql)
+    } catch ex {
+        write $$$ZENJSSTR($System.Status.GetErrorText(ex.AsStatus()))
+    }
+    return $$$OK
 ]]></Implementation>
 </Method>
 
@@ -117,14 +130,14 @@ Converts incoming request object and calls abovementioned method.]]></Descriptio
 <ClassMethod>1</ClassMethod>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set st = $$$OK
-	set obj = ##class(%ZEN.proxyObject).%New()
-	set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
-	return:$$$ISERR(st) st
-	set tMDX = obj.MDX
-	set tMDX = $ZCVT(tMDX,"I","UTF8")
-  	set st = ##class(MDX2JSON.Utils).WriteDrillthroughJSON(tMDX)
-  	return st
+    set st = $$$OK
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
+    return:$$$ISERR(st) st
+    set tMDX = obj.MDX
+    set tMDX = $ZCVT(tMDX,"I","UTF8")
+    set st = ##class(MDX2JSON.Utils).WriteDrillthroughJSON(tMDX)
+    return st
 ]]></Implementation>
 </Method>
 
@@ -193,25 +206,25 @@ Converts incoming request object and calls abovementioned method.]]></Descriptio
 <ProcedureBlock>0</ProcedureBlock>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set callback=$get(%request.Data("callback",1),"")
-	write:(callback'="") callback_"("
-	
-	set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)	
+    set callback=$get(%request.Data("callback",1),"")
+    write:(callback'="") callback_"("
+    
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)    
  
-	return:$$$ISERR(st) st
-	return:'$IsObject(obj) $$$ERROR($$$ArgumentIsNotAnObject,"Body")
-	
-	try {
-		set tMDX = obj.MDX
-		set tMDX = $ZCVT(tMDX,"I","UTF8")
-		set st = ##class(MDX2JSON.Utils).WriteJSONfromMDX(tMDX)
-	} catch ex {
-		//zw obj
-		set st=ex.AsStatus()
-	}
+    return:$$$ISERR(st) st
+    return:'$IsObject(obj) $$$ERROR($$$ArgumentIsNotAnObject,"Body")
+    
+    try {
+        set tMDX = obj.MDX
+        set tMDX = $ZCVT(tMDX,"I","UTF8")
+        set st = ##class(MDX2JSON.Utils).WriteJSONfromMDX(tMDX)
+    } catch ex {
+        //zw obj
+        set st=ex.AsStatus()
+    }
 
-  	write:(callback'="") ")"
-  	return st
+    write:(callback'="") ")"
+    return st
 ]]></Implementation>
 </Method>
 
@@ -222,12 +235,12 @@ Converts incoming request object and calls abovementioned method.]]></Descriptio
 <ClassMethod>1</ClassMethod>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set st = $$$OK
-	set obj = ##class(%ZEN.proxyObject).%New()
-	set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
-	quit:$$$ISERR(st) st
-  	set st = ##class(MDX2JSON.Utils).WriteJSONPfromMDX(obj.MDX)
-  	quit st
+    set st = $$$OK
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
+    quit:$$$ISERR(st) st
+    set st = ##class(MDX2JSON.Utils).WriteJSONPfromMDX(obj.MDX)
+    quit st
 ]]></Implementation>
 </Method>
 
@@ -238,12 +251,12 @@ Converts incoming request object and calls abovementioned method.]]></Descriptio
 <ClassMethod>1</ClassMethod>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set st=$$$OK
-	set obj = ##class(%ZEN.proxyObject).%New()
-	set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
-	quit:$$$ISERR(st) st
-  	set st = ##class(MDX2JSON.Utils).WriteXMLAfromMDX(obj.MDX)
-  	quit st
+    set st=$$$OK
+    set obj = ##class(%ZEN.proxyObject).%New()
+    set st = ##class(%ZEN.Auxiliary.jsonProvider).%ConvertJSONToObject(%request.Content,,.obj,1)
+    quit:$$$ISERR(st) st
+    set st = ##class(MDX2JSON.Utils).WriteXMLAfromMDX(obj.MDX)
+    quit st
 ]]></Implementation>
 </Method>
 
@@ -256,9 +269,9 @@ Add param Namespace to a request to execute MDX in desired namespace.]]></Descri
 <FormalSpec>pUrl:%String,pMethod:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	do %response.SetHeader("Access-Control-Allow-Origin","*")
-	do %response.SetHeader("Access-Control-Allow-Headers","Authorization")
-	
+    do %response.SetHeader("Access-Control-Allow-Origin","*")
+    do %response.SetHeader("Access-Control-Allow-Headers","Authorization")
+    
     #dim tSC As %Status = $$$OK
     #dim e As %Exception.AbstractException
     
@@ -337,14 +350,14 @@ Add param Namespace to a request to execute MDX in desired namespace.]]></Descri
                 set Namespace = $get(%request.Data("Namespace",1))
                 
                 if (##class(%SYS.Namespace).Exists(Namespace)) {
-                	set oldNS = $Namespace
-                	zn Namespace
-                	set tSC=$zobjclassmethod(tClass,tTarget,tArgs...)
-                	zn oldNS
+                    set oldNS = $Namespace
+                    zn Namespace
+                    set tSC=$zobjclassmethod(tClass,tTarget,tArgs...)
+                    zn oldNS
                 } elseif (Namespace = "") {
-	                set tSC=$zobjclassmethod(tClass,tTarget,tArgs...)
+                    set tSC=$zobjclassmethod(tClass,tTarget,tArgs...)
                 }else {
-	                set tSC = $$$ERROR($$$NamespaceUnavailable,Namespace)                	
+                    set tSC = $$$ERROR($$$NamespaceUnavailable,Namespace)                   
                 }
                 If $$$ISERR(tSC) Do ..Http500(tSC)
                 
@@ -378,7 +391,7 @@ Issue an '500' error and give some indication as to what occurred.<br>
 <ClassMethod>1</ClassMethod>
 <FormalSpec>pStatus:%Exception.AbstractException</FormalSpec>
 <Implementation><![CDATA[
-	// we are expecting status
+    // we are expecting status
     #; Set the response Http status
     Set %response.Status="500 Internal Server Error"
     

--- a/MDX2JSON/Utils.cls.xml
+++ b/MDX2JSON/Utils.cls.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Export generator="Cache" version="25">
+<Export generator="Cache" version="25" zv="Cache for Windows (x86-64) 2014.1.1 (Build 702U)" ts="2014-11-24 20:24:41">
 <Class name="MDX2JSON.Utils">
 <Description><![CDATA[
 Utility class, wrappers for processing of MDX queries in <b>MDX2JSON.ResultSet</b>.
 Outputs JSON, JSONP and XML/A.<br>
 Also has functionality for getting information about cubes, dashboards and widgets.]]></Description>
 <IncludeCode>MDX2JSON.MDX2JSON</IncludeCode>
+<TimeChanged>63515,68202.401147</TimeChanged>
 <TimeCreated>63165,65653.547419</TimeCreated>
 
 <Method name="GetResultSet">
@@ -17,7 +18,7 @@ Transforms MDX query into executed <b>MDX2JSON.ResultSet</b>.<br>
 <FormalSpec>pMDX:%String,*pStatus</FormalSpec>
 <ReturnType>MDX2JSON.ResultSet</ReturnType>
 <Implementation><![CDATA[
-	set Params = ""
+    set Params = ""
     set pStatus = $$$OK
     set RS = ##class(MDX2JSON.ResultSet).%ExecuteDirect(pMDX,.Params,.pStatus)
     return RS
@@ -32,7 +33,7 @@ Automatic processing of MDX query and outputting resulting JSON.<br>
 <FormalSpec>pMDX:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	#dim RS As MDX2JSON.ResultSet
+    #dim RS As MDX2JSON.ResultSet
     set RS = ..GetResultSet(pMDX,.st)      
     return:$$$ISERR(st) st
         
@@ -52,13 +53,13 @@ Automatic processing of MDX query and outputting resulting JSONP.<br>
 <FormalSpec>pMDX:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set RS = ..GetResultSet(pMDX,.st)
-	return:$$$ISERR(st) st
-	
-	set PageSize = 1000
-	set CurrPage = 1
-	set st = RS.%OutputJSON(PageSize,CurrPage,,PageSize)
-	return st
+    set RS = ..GetResultSet(pMDX,.st)
+    return:$$$ISERR(st) st
+    
+    set PageSize = 1000
+    set CurrPage = 1
+    set st = RS.%OutputJSON(PageSize,CurrPage,,PageSize)
+    return st
 ]]></Implementation>
 </Method>
 
@@ -70,9 +71,9 @@ Automatic processing of MDX Drillthrough query and outputting resulting listing 
 <FormalSpec>pMDX:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set RS = ..GetResultSet(pMDX,.st)
-	return:$$$ISERR(st) st
-	
+    set RS = ..GetResultSet(pMDX,.st)
+    return:$$$ISERR(st) st
+    
     set SQL = RS.%GetListingSQL()
     do ##class(%ZEN.Auxiliary.jsonSQLProvider).%WriteJSONFromSQL(,SQL,,$$$MaxCacheInt)
 
@@ -88,10 +89,10 @@ Automatic processing of MDX query and outputting resulting XML/A.<br>
 <FormalSpec>pMDX:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set RS = ..GetResultSet(pMDX,.st)
-	return:$$$ISERR(st) st        
-	
-	set st = RS.%OutputXMLA()
+    set RS = ..GetResultSet(pMDX,.st)
+    return:$$$ISERR(st) st        
+    
+    set st = RS.%OutputXMLA()
 
     return st
 ]]></Implementation>
@@ -105,8 +106,8 @@ Gets filters for MDX expression.<br>
 <FormalSpec>pMDX:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set RS = ..GetResultSet(pMDX,.st)
-	return:$$$ISERR(st) st 
+    set RS = ..GetResultSet(pMDX,.st)
+    return:$$$ISERR(st) st 
     
     set st=RS.%GetFiltersForCellRange(.filters,0,0,RS.%GetAxisSize(2),RS.%GetAxisSize(1),.measure)
 
@@ -139,7 +140,7 @@ Get all values for Filter for DeepSee Cube in JSON format.<br>
 <FormalSpec>pCube:%String,pFilter:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	set st = ##class(%DeepSee.Dashboard.Utils).%GetMembersForFilter(pCube,pFilter,.tFilters,.tDefaultFilterValue,,.tRelatedFilters,0,,.tValueList)
+    set st = ##class(%DeepSee.Dashboard.Utils).%GetMembersForFilter(pCube,pFilter,.tFilters,.tDefaultFilterValue,,.tRelatedFilters,0,,.tValueList)
     return:$$$ISERR(st) st 
     
     set st = ##class(%ZEN.Auxiliary.jsonProvider).%ArrayToJSON($lb("name","value"),.tFilters)
@@ -157,20 +158,51 @@ Returns MDX string used to create pivot.<br>
 <FormalSpec>pPivotName:%String,*pStatus:%Status=$$$OK</FormalSpec>
 <ReturnType>%String</ReturnType>
 <Implementation><![CDATA[
-	set tPivot = ##class(%DeepSee.UserLibrary.Utils).%OpenFolderItem(pPivotName,.pStatus)
-	return:$$$ISERR(pStatus) $System.Status.GetErrorText(pStatus)
+    set tPivot = ##class(%DeepSee.UserLibrary.Utils).%OpenFolderItem(pPivotName,.pStatus)
+    return:$$$ISERR(pStatus) $System.Status.GetErrorText(pStatus)
 
-	set tPivotTable = ##class(%DeepSee.Component.pivotTable).%New()
-	set st = tPivot.%CopyToComponent(tPivotTable)
-	return:$$$ISERR(pStatus) $System.Status.GetErrorText(pStatus)
+    set tPivotTable = ##class(%DeepSee.Component.pivotTable).%New()
+    set st = tPivot.%CopyToComponent(tPivotTable)
+    return:$$$ISERR(pStatus) $System.Status.GetErrorText(pStatus)
 
-	set rs = tPivotTable.%CreateResultSet(.st,.tParms,.tFilterInfo,.tAdvancedFilters,.tQueryText)
-	return:$$$ISERR(pStatus) $System.Status.GetErrorText(pStatus)
-	
-	set pMDX = tQueryText
-	set pStatus = $$$OK
-		
-  	return pMDX
+    set rs = tPivotTable.%CreateResultSet(.st,.tParms,.tFilterInfo,.tAdvancedFilters,.tQueryText)
+    return:$$$ISERR(pStatus) $System.Status.GetErrorText(pStatus)
+    
+    set pMDX = tQueryText
+    set pStatus = $$$OK
+        
+    return pMDX
+]]></Implementation>
+</Method>
+
+<Method name="GetDataSource">
+<ClassMethod>1</ClassMethod>
+<FormalSpec>pDataSource:%String</FormalSpec>
+<Implementation><![CDATA[
+    
+    set st = $$$OK
+    try {
+        
+        if ($FIND(pDataSource, ".pivot") = ($LENGTH(pDataSource) + 1)) {
+            &sql(
+                SELECT TOP 1 ID into :sourceId
+                FROM %DeepSee_Dashboard.Pivot
+                WHERE fullName=:pDataSource
+            )
+            return:(SQLCODE'=0) $$$ERROR($$$SQLError, SQLCODE)
+            
+            set dataSource = ##class(%DeepSee.Dashboard.Pivot).%OpenId(sourceId,,.st)
+            return:($$$ISERR(st)) st
+            
+            do ##class(%ZEN.Auxiliary.jsonProvider).%ObjectToJSON(dataSource, .out)
+            
+        }
+         
+    } catch ex {
+        set st = ex.AsStatus()
+    }
+    
+    return st
 ]]></Implementation>
 </Method>
 
@@ -182,38 +214,38 @@ Using dashboard name get JSON representation (array of ("type","title","mdx")) o
 <FormalSpec>pDashName:%String</FormalSpec>
 <ReturnType>%Status</ReturnType>
 <Implementation><![CDATA[
-	#Dim widgets As List Of %DeepSee.Dashboard.Widget
-	#Dim widget As %DeepSee.Dashboard.Widget
-	
-	set st = $$$OK
-	try {
-		
-		&sql(
-			SELECT TOP 1 ID into :tDashId
-			FROM %DeepSee_Dashboard.Definition
-			WHERE fullName=:pDashName
-		)
-		return:(SQLCODE'=0) $$$ERROR($$$SQLError, SQLCODE)
+    #Dim widgets As List Of %DeepSee.Dashboard.Widget
+    #Dim widget As %DeepSee.Dashboard.Widget
+    
+    set st = $$$OK
+    try {
+        
+        &sql(
+            SELECT TOP 1 ID into :tDashId
+            FROM %DeepSee_Dashboard.Definition
+            WHERE fullName=:pDashName
+        )
+        return:(SQLCODE'=0) $$$ERROR($$$SQLError, SQLCODE)
 
-		set dash = ##class(%DeepSee.Dashboard.Definition).%OpenId(tDashId,,.st)
+        set dash = ##class(%DeepSee.Dashboard.Definition).%OpenId(tDashId,,.st)
 
-		return:($$$ISERR(st)) st
-		set widgets = dash.widgets.%ConstructClone("true")
-		//Widget : {type, title, key, mdx}
+        return:($$$ISERR(st)) st
+        set widgets = dash.widgets.%ConstructClone("true")
+        //Widget : {type, title, key, mdx}
 
-		set widget = widgets.GetNext(.key)
-		
-		do {
-			set out(key) =$lb(widget.subtype, widget.title, widget.key, ..GetMdx(widget.dataSource))
-			set widget = widgets.GetNext(.key)
-		} while (key'="")
+        set widget = widgets.GetNext(.key)
+        
+        do {
+            set out(key) =$lb(widget.subtype, widget.title, widget.key, ..GetMdx(widget.dataSource), widget.dataSource)
+            set widget = widgets.GetNext(.key)
+        } while (key'="")
 
-		do ##class(%ZEN.Auxiliary.jsonProvider).%ArrayToJSON($lb("type","title","key","mdx"),.out)
-		
-	} catch ex {
-		set st = ex.AsStatus()
-	}
-	return st
+        do ##class(%ZEN.Auxiliary.jsonProvider).%ArrayToJSON($lb("type","title","key","mdx","dataSource"),.out)
+        
+    } catch ex {
+        set st = ex.AsStatus()
+    }
+    return st
 ]]></Implementation>
 </Method>
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These are the possible requests to web application (add param ?Namespace={Desire
 | MDX2XMLA                    | POST | { "MDX":"QUERY" }           | XMLA      | Results of MDX execution       |
 | Dashboards                  | GET  |                             | JSON      | All dashboards                 |
 | Widgets                     | POST | {Dashboard:"DashboardName"} | JSON      | All widgets in a dashboard     |
+| DataSource                  | POST | {DataSource:"Name of DS"}   | JSON      | All info about data source     |
 | FilterValues/:cube         | GET  |                             | JSON      | All filters for DeepSee Cube   |
 | FilterValues/:cube/:filter | GET  |                             | JSON      | All possible values for filter |
 | Test                        | GET  |                             | plaintext | Test info                      |


### PR DESCRIPTION
I have added a <code>/DataSource</code> route and suitable methods to retreve data source information. Also I have changed <code>GetWidgetsList</code> method so that in a list of widgets will appear <code>dataSource</code> property, that can be passed to <code>/DataSource</code> requests.

Example: request to <code>http://localhost:57772/samples/DataSource</code> with data

``` js
{
    DataSource:"KPIs & Plugins/HoleFoods.pivot"
}
```

will return something like

``` js
{
    "_class":"%DeepSee.Dashboard.Pivot",
    "_id":25,
    "name":"HoleFoods",
    "folder": {
        "_class":"%DeepSee.UserLibrary.Folder",
        "_id":4,
        "fullName":"KPIs & Plugins",
        "name":"KPIs & Plugins",
        "folder":null,
        "items":[],
        "resource":""
    },
    "folderName":"KPIs & Plugins",
    "fullName":"KPIs & Plugins\/HoleFoods.pivot",
    "documentName":"KPIs & Plugins-HoleFoods.pivot.DFI",
    "title":"",
    "description":"",
    "keywords":"HoleFoods,Plugin",
    "owner":"",
    "shared":true,
    "public":false,
    "locked":false,
    "resource":"",
    "timeCreated":"2013-01-07 22:48:41.31",
    "timeModified":"2014-06-06 21:16:34.487",
    "...": "...",
    "showStatus":true,
    "rowAxisOptions": { "...": "..." },
    "...": "..."
}
```

This is important for my [light pivot table project](https://github.com/ZitRos/LightPivotTable), because I can examine all source settings, such as custom drillDown specs.
